### PR TITLE
Updates to README for ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,24 @@ Has been written as:
   * Build an image, only sandbox
 
 ## To build
+You will need to install another go module called trash, which will help handle some of the Docker dependencies. It is called "trash". The following command will install an executable "trash" into your `$GOPATH/bin`
 
 ```
 $ go get github.com/rancher/trash
+```
+
+and then you can run it to build this executable.
+
+```
 $ trash
 $ go build
 ```
+
 If you do not need ostree support, or do not have gpgme available you can use
 build tags to exclude those features of `containers/image`:
 
 ```
-$ go build --tags containers_image_openpgp,containers_image_ostree_stub
+$ go build --tags "containers_image_openpgp containers_image_ostree_stub"
 ```
 
 


### PR DESCRIPTION
This will eventually go into some nice installer, but for now since we have a lot of different developers (on different OS) getting the basic setup working, having notes for debugging in the README is very helpful. In this specific case, I was missing install of two libraries using apt-get that allowed me to build (with flags). I am also adding a .gitignore so we don't accidentally add executables or the vendor folder.